### PR TITLE
Remove Autowired annotations

### DIFF
--- a/src/main/kotlin/net/relaxism/devtools/webdevtools/component/api/GeoIpClient.kt
+++ b/src/main/kotlin/net/relaxism/devtools/webdevtools/component/api/GeoIpClient.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.coroutineScope
 import net.relaxism.devtools.webdevtools.config.ApplicationProperties
 import net.relaxism.devtools.webdevtools.utils.JsonUtils
 import org.slf4j.Logger
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
@@ -12,9 +11,9 @@ import org.springframework.web.reactive.function.client.awaitBody
 
 @Component
 class GeoIpClient(
-    @Autowired private val logger: Logger,
-    @Autowired private val applicationProperties: ApplicationProperties,
-    @Autowired private val webClient: WebClient,
+    private val logger: Logger,
+    private val applicationProperties: ApplicationProperties,
+    private val webClient: WebClient,
 ) {
     suspend fun getGeoByIpAddress(ipAddressString: String): Map<String, Any?> =
         coroutineScope {

--- a/src/main/kotlin/net/relaxism/devtools/webdevtools/component/api/RdapClient.kt
+++ b/src/main/kotlin/net/relaxism/devtools/webdevtools/component/api/RdapClient.kt
@@ -11,7 +11,6 @@ import net.relaxism.devtools.webdevtools.utils.JsonUtils
 import net.relaxism.devtools.webdevtools.utils.PathUtils
 import org.slf4j.Logger
 import org.springframework.beans.factory.InitializingBean
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
@@ -22,9 +21,9 @@ import java.net.URI
 
 @Component
 class RdapClient(
-    @Autowired private val logger: Logger,
-    @Autowired private val applicationProperties: ApplicationProperties,
-    @Autowired private val webClient: WebClient,
+    private val logger: Logger,
+    private val applicationProperties: ApplicationProperties,
+    private val webClient: WebClient,
 ) : InitializingBean {
     private lateinit var rdapUriByIpAddressRange: RangeMap<IPAddress, URI>
 

--- a/src/main/kotlin/net/relaxism/devtools/webdevtools/config/ApplicationConfig.kt
+++ b/src/main/kotlin/net/relaxism/devtools/webdevtools/config/ApplicationConfig.kt
@@ -1,7 +1,6 @@
 package net.relaxism.devtools.webdevtools.config
 
 import org.slf4j.Logger
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
@@ -14,7 +13,7 @@ import reactor.netty.http.client.HttpClient
 @Configuration
 @EnableConfigurationProperties(ApplicationProperties::class)
 class ApplicationConfiguration(
-    @Autowired private val logger: Logger,
+    private val logger: Logger,
 ) {
     @Bean
     fun webClient(): WebClient =

--- a/src/main/kotlin/net/relaxism/devtools/webdevtools/config/RoutingConfig.kt
+++ b/src/main/kotlin/net/relaxism/devtools/webdevtools/config/RoutingConfig.kt
@@ -6,7 +6,6 @@ import net.relaxism.devtools.webdevtools.handler.HttpHeadersApiHandler
 import net.relaxism.devtools.webdevtools.handler.IndexHandler
 import net.relaxism.devtools.webdevtools.handler.IpApiHandler
 import net.relaxism.devtools.webdevtools.handler.RdapApiHandler
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.MediaType
@@ -14,13 +13,13 @@ import org.springframework.web.reactive.function.server.coRouter
 
 @Configuration
 class RoutingConfig(
-    @Autowired private val applicationProperties: ApplicationProperties,
-    @Autowired private val indexHandler: IndexHandler,
-    @Autowired private val ipApiHandler: IpApiHandler,
-    @Autowired private val rdapApiHandler: RdapApiHandler,
-    @Autowired private val geoApiHandler: GeoApiHandler,
-    @Autowired private val httpHeadersApiHandler: HttpHeadersApiHandler,
-    @Autowired private val htmlEntitiesApiHandler: HtmlEntitiesApiHandler,
+    private val applicationProperties: ApplicationProperties,
+    private val indexHandler: IndexHandler,
+    private val ipApiHandler: IpApiHandler,
+    private val rdapApiHandler: RdapApiHandler,
+    private val geoApiHandler: GeoApiHandler,
+    private val httpHeadersApiHandler: HttpHeadersApiHandler,
+    private val htmlEntitiesApiHandler: HtmlEntitiesApiHandler,
 ) {
     @Bean
     fun apiRouter() =

--- a/src/main/kotlin/net/relaxism/devtools/webdevtools/config/WebFluxConfig.kt
+++ b/src/main/kotlin/net/relaxism/devtools/webdevtools/config/WebFluxConfig.kt
@@ -1,13 +1,12 @@
 package net.relaxism.devtools.webdevtools.config
 
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.config.CorsRegistry
 import org.springframework.web.reactive.config.WebFluxConfigurer
 
 @Configuration
 class WebFluxConfig(
-    @Autowired val applicationProperties: ApplicationProperties,
+    val applicationProperties: ApplicationProperties,
 ) : WebFluxConfigurer {
     override fun addCorsMappings(corsRegistry: CorsRegistry) {
         val corsProperties = applicationProperties.cors

--- a/src/main/kotlin/net/relaxism/devtools/webdevtools/handler/GeoApiHandler.kt
+++ b/src/main/kotlin/net/relaxism/devtools/webdevtools/handler/GeoApiHandler.kt
@@ -1,7 +1,6 @@
 package net.relaxism.devtools.webdevtools.handler
 
 import net.relaxism.devtools.webdevtools.service.GeoIpService
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.ServerRequest
@@ -10,7 +9,7 @@ import org.springframework.web.reactive.function.server.bodyValueAndAwait
 
 @Component
 class GeoApiHandler(
-    @Autowired private val geoIpService: GeoIpService,
+    private val geoIpService: GeoIpService,
 ) {
     suspend fun getGeo(request: ServerRequest): ServerResponse {
         val ipAddress = request.pathVariable("ip")

--- a/src/main/kotlin/net/relaxism/devtools/webdevtools/handler/HtmlEntitiesApiHandler.kt
+++ b/src/main/kotlin/net/relaxism/devtools/webdevtools/handler/HtmlEntitiesApiHandler.kt
@@ -1,7 +1,6 @@
 package net.relaxism.devtools.webdevtools.handler
 
 import net.relaxism.devtools.webdevtools.service.HtmlEntityService
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
@@ -14,7 +13,7 @@ import org.springframework.web.reactive.function.server.bodyValueAndAwait
 
 @Component
 class HtmlEntitiesApiHandler(
-    @Autowired private val htmlEntityService: HtmlEntityService,
+    private val htmlEntityService: HtmlEntityService,
 ) {
     suspend fun getHtmlEntities(request: ServerRequest): ServerResponse {
         val name = request.queryParam("name").orElse("")

--- a/src/main/kotlin/net/relaxism/devtools/webdevtools/handler/IndexHandler.kt
+++ b/src/main/kotlin/net/relaxism/devtools/webdevtools/handler/IndexHandler.kt
@@ -1,7 +1,6 @@
 package net.relaxism.devtools.webdevtools.handler
 
 import net.relaxism.devtools.webdevtools.config.ApplicationProperties
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.ServerRequest
@@ -10,7 +9,7 @@ import org.springframework.web.reactive.function.server.bodyValueAndAwait
 
 @Component
 class IndexHandler(
-    @Autowired private val applicationProperties: ApplicationProperties,
+    private val applicationProperties: ApplicationProperties,
 ) {
     suspend fun getIndex(request: ServerRequest): ServerResponse =
         ServerResponse

--- a/src/main/kotlin/net/relaxism/devtools/webdevtools/handler/RdapApiHandler.kt
+++ b/src/main/kotlin/net/relaxism/devtools/webdevtools/handler/RdapApiHandler.kt
@@ -2,7 +2,6 @@ package net.relaxism.devtools.webdevtools.handler
 
 import net.relaxism.devtools.webdevtools.component.api.RdapClient
 import net.relaxism.devtools.webdevtools.service.RdapService
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.ServerRequest
@@ -12,7 +11,7 @@ import org.springframework.web.reactive.function.server.buildAndAwait
 
 @Component
 class RdapApiHandler(
-    @Autowired private val rdapService: RdapService,
+    private val rdapService: RdapService,
 ) {
     suspend fun getRdap(request: ServerRequest): ServerResponse {
         val ipAddress = request.pathVariable("ip")

--- a/src/main/kotlin/net/relaxism/devtools/webdevtools/service/GeoIpService.kt
+++ b/src/main/kotlin/net/relaxism/devtools/webdevtools/service/GeoIpService.kt
@@ -1,12 +1,11 @@
 package net.relaxism.devtools.webdevtools.service
 
 import net.relaxism.devtools.webdevtools.component.api.GeoIpClient
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 
 @Service
 class GeoIpService(
-    @Autowired private val geoIpClient: GeoIpClient,
+    private val geoIpClient: GeoIpClient,
 ) {
     suspend fun getGeoFromIpAddress(ipAddress: String) = geoIpClient.getGeoByIpAddress(ipAddress)
 }

--- a/src/main/kotlin/net/relaxism/devtools/webdevtools/service/HtmlEntityService.kt
+++ b/src/main/kotlin/net/relaxism/devtools/webdevtools/service/HtmlEntityService.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitSingle
 import net.relaxism.devtools.webdevtools.repository.HtmlEntity
 import net.relaxism.devtools.webdevtools.repository.HtmlEntityRepository
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
@@ -16,7 +15,7 @@ import org.springframework.stereotype.Service
 
 @Service
 class HtmlEntityService(
-    @Autowired private val htmlEntityRepository: HtmlEntityRepository,
+    private val htmlEntityRepository: HtmlEntityRepository,
 ) {
     suspend fun findAll(): Flow<HtmlEntity> = htmlEntityRepository.findAll().asFlow()
 

--- a/src/main/kotlin/net/relaxism/devtools/webdevtools/service/RdapService.kt
+++ b/src/main/kotlin/net/relaxism/devtools/webdevtools/service/RdapService.kt
@@ -1,12 +1,11 @@
 package net.relaxism.devtools.webdevtools.service
 
 import net.relaxism.devtools.webdevtools.component.api.RdapClient
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 
 @Service
 class RdapService(
-    @Autowired private val rdapClient: RdapClient,
+    private val rdapClient: RdapClient,
 ) {
     suspend fun getRdapByIpAddress(ipAddress: String) = rdapClient.getRdapByIpAddress(ipAddress)
 }


### PR DESCRIPTION
Eliminate the use of `@Autowired` annotations in favor of constructor injection for better clarity and consistency in dependency management.