### PR TITLE
refactor: migrate HtmlEntityRepository to CoroutineCrudRepository

### DIFF
--- a/src/main/kotlin/net/relaxism/devtools/webdevtools/repository/HtmlEntityRepository.kt
+++ b/src/main/kotlin/net/relaxism/devtools/webdevtools/repository/HtmlEntityRepository.kt
@@ -1,13 +1,12 @@
 package net.relaxism.devtools.webdevtools.repository
 
+import kotlinx.coroutines.flow.Flow
 import org.springframework.data.annotation.Id
 import org.springframework.data.domain.Pageable
 import org.springframework.data.relational.core.mapping.Column
 import org.springframework.data.relational.core.mapping.Table
-import org.springframework.data.repository.reactive.ReactiveCrudRepository
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 import org.springframework.stereotype.Repository
-import reactor.core.publisher.Flux
-import reactor.core.publisher.Mono
 
 @Table
 data class HtmlEntity(
@@ -21,11 +20,11 @@ data class HtmlEntity(
 )
 
 @Repository
-interface HtmlEntityRepository : ReactiveCrudRepository<HtmlEntity, Long> {
-    fun countByNameContaining(name: String): Mono<Long>
+interface HtmlEntityRepository : CoroutineCrudRepository<HtmlEntity, Long> {
+    suspend fun countByNameContaining(name: String): Long
 
     fun findByNameContaining(
         name: String,
         pageable: Pageable,
-    ): Flux<HtmlEntity>
+    ): Flow<HtmlEntity>
 }

--- a/src/main/kotlin/net/relaxism/devtools/webdevtools/service/HtmlEntityService.kt
+++ b/src/main/kotlin/net/relaxism/devtools/webdevtools/service/HtmlEntityService.kt
@@ -4,8 +4,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.reactive.asFlow
-import kotlinx.coroutines.reactive.awaitSingle
 import net.relaxism.devtools.webdevtools.repository.HtmlEntity
 import net.relaxism.devtools.webdevtools.repository.HtmlEntityRepository
 import org.springframework.data.domain.Page
@@ -17,17 +15,16 @@ import org.springframework.stereotype.Service
 class HtmlEntityService(
     private val htmlEntityRepository: HtmlEntityRepository,
 ) {
-    suspend fun findAll(): Flow<HtmlEntity> = htmlEntityRepository.findAll().asFlow()
+    suspend fun findAll(): Flow<HtmlEntity> = htmlEntityRepository.findAll()
 
     suspend fun findByNameContaining(
         name: String,
         pageable: Pageable,
     ): Page<HtmlEntity> =
         coroutineScope {
-            val countDeferred = async { htmlEntityRepository.countByNameContaining(name).awaitSingle() }
-            val entitiesDeferred = async { htmlEntityRepository.findByNameContaining(name, pageable).asFlow().toList() }
-
-            (countDeferred.await() to entitiesDeferred.await())
-                .let { (count, entities) -> PageImpl(entities, pageable, count) }
+            async { htmlEntityRepository.countByNameContaining(name) } to
+                async { htmlEntityRepository.findByNameContaining(name, pageable).toList() }
+        }.let { (countDeferred, entitiesDeferred) ->
+            PageImpl(entitiesDeferred.await(), pageable, countDeferred.await())
         }
 }

--- a/src/test/kotlin/net/relaxism/devtools/webdevtools/repository/HtmlEntityRepositorySpec.kt
+++ b/src/test/kotlin/net/relaxism/devtools/webdevtools/repository/HtmlEntityRepositorySpec.kt
@@ -4,8 +4,8 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNotBe
-import kotlinx.coroutines.reactive.awaitFirst
-import kotlinx.coroutines.reactive.awaitFirstOrNull
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.toList
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.domain.PageRequest
 
@@ -23,8 +23,7 @@ class HtmlEntityRepositorySpec(
             val entities =
                 htmlEntityRepository
                     .findByNameContaining("amp", pageable)
-                    .collectList()
-                    .awaitFirst()
+                    .toList()
 
             entities shouldNotBe null
             entities.should { list ->
@@ -33,10 +32,7 @@ class HtmlEntityRepositorySpec(
         }
 
         test("countByNameContaining should return count of entities matching the name pattern") {
-            val count =
-                htmlEntityRepository
-                    .countByNameContaining("amp")
-                    .awaitFirst()
+            val count = htmlEntityRepository.countByNameContaining("amp")
 
             count shouldNotBe null
             count shouldBeGreaterThan 0L
@@ -46,8 +42,7 @@ class HtmlEntityRepositorySpec(
             val entities =
                 htmlEntityRepository
                     .findAll()
-                    .collectList()
-                    .awaitFirst()
+                    .toList()
 
             entities shouldNotBe null
             entities.size shouldBeGreaterThan 0
@@ -57,14 +52,10 @@ class HtmlEntityRepositorySpec(
             val firstEntity =
                 htmlEntityRepository
                     .findAll()
-                    .take(1)
-                    .awaitFirstOrNull()
+                    .firstOrNull()
 
             if (firstEntity != null && firstEntity.id != null) {
-                val foundEntity =
-                    htmlEntityRepository
-                        .findById(firstEntity.id!!)
-                        .awaitFirstOrNull()
+                val foundEntity = htmlEntityRepository.findById(firstEntity.id!!)
 
                 foundEntity shouldNotBe null
                 foundEntity!!.id shouldNotBe null

--- a/src/test/kotlin/net/relaxism/devtools/webdevtools/service/HtmlEntityServiceSpec.kt
+++ b/src/test/kotlin/net/relaxism/devtools/webdevtools/service/HtmlEntityServiceSpec.kt
@@ -5,14 +5,14 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.mockk.coEvery
 import io.mockk.every
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import net.relaxism.devtools.webdevtools.repository.HtmlEntity
 import net.relaxism.devtools.webdevtools.repository.HtmlEntityRepository
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.domain.PageRequest
-import reactor.core.publisher.Flux
-import reactor.core.publisher.Mono
 
 @SpringBootTest
 class HtmlEntityServiceSpec(
@@ -30,7 +30,7 @@ class HtmlEntityServiceSpec(
                     HtmlEntity(1L, "amp", 38L, null, "HTML", "HTML", "ampersand"),
                     HtmlEntity(2L, "quot", 34L, null, "HTML", "HTML", "quotation mark"),
                 )
-            every { mockHtmlEntityRepository.findAll() } returns Flux.fromIterable(mockEntities)
+            every { mockHtmlEntityRepository.findAll() } returns flowOf(*mockEntities.toTypedArray())
 
             val entities = htmlEntityService.findAll().toList()
 
@@ -45,8 +45,8 @@ class HtmlEntityServiceSpec(
                 listOf(
                     HtmlEntity(1L, "amp", 38L, null, "HTML", "HTML", "ampersand"),
                 )
-            every { mockHtmlEntityRepository.countByNameContaining("amp") } returns Mono.just(1L)
-            every { mockHtmlEntityRepository.findByNameContaining("amp", pageable) } returns Flux.fromIterable(mockEntities)
+            coEvery { mockHtmlEntityRepository.countByNameContaining("amp") } returns 1L
+            every { mockHtmlEntityRepository.findByNameContaining("amp", pageable) } returns flowOf(*mockEntities.toTypedArray())
 
             val page = htmlEntityService.findByNameContaining("amp", pageable)
 
@@ -65,8 +65,8 @@ class HtmlEntityServiceSpec(
                     HtmlEntity(1L, "amp", 38L, null, "HTML", "HTML", "ampersand"),
                     HtmlEntity(2L, "quot", 34L, null, "HTML", "HTML", "quotation mark"),
                 )
-            every { mockHtmlEntityRepository.countByNameContaining("") } returns Mono.just(2L)
-            every { mockHtmlEntityRepository.findByNameContaining("", pageable) } returns Flux.fromIterable(mockEntities)
+            coEvery { mockHtmlEntityRepository.countByNameContaining("") } returns 2L
+            every { mockHtmlEntityRepository.findByNameContaining("", pageable) } returns flowOf(*mockEntities.toTypedArray())
 
             val page = htmlEntityService.findByNameContaining("", pageable)
 
@@ -81,8 +81,8 @@ class HtmlEntityServiceSpec(
                 listOf(
                     HtmlEntity(1L, "amp", 38L, null, "HTML", "HTML", "ampersand"),
                 )
-            every { mockHtmlEntityRepository.countByNameContaining("") } returns Mono.just(1L)
-            every { mockHtmlEntityRepository.findByNameContaining("", pageable) } returns Flux.fromIterable(mockEntities)
+            coEvery { mockHtmlEntityRepository.countByNameContaining("") } returns 1L
+            every { mockHtmlEntityRepository.findByNameContaining("", pageable) } returns flowOf(*mockEntities.toTypedArray())
 
             val page = htmlEntityService.findByNameContaining("", pageable)
 
@@ -98,10 +98,10 @@ class HtmlEntityServiceSpec(
                 listOf(
                     HtmlEntity(1L, "amp", 38L, null, "HTML", "HTML", "ampersand"),
                 )
-            every { mockHtmlEntityRepository.countByNameContaining("amp") } returns Mono.just(1L)
-            every { mockHtmlEntityRepository.findByNameContaining("amp", pageable) } returns Flux.fromIterable(mockEntities)
-            every { mockHtmlEntityRepository.countByNameContaining("AMP") } returns Mono.just(1L)
-            every { mockHtmlEntityRepository.findByNameContaining("AMP", pageable) } returns Flux.fromIterable(mockEntities)
+            coEvery { mockHtmlEntityRepository.countByNameContaining("amp") } returns 1L
+            every { mockHtmlEntityRepository.findByNameContaining("amp", pageable) } returns flowOf(*mockEntities.toTypedArray())
+            coEvery { mockHtmlEntityRepository.countByNameContaining("AMP") } returns 1L
+            every { mockHtmlEntityRepository.findByNameContaining("AMP", pageable) } returns flowOf(*mockEntities.toTypedArray())
 
             val lowerCasePage = htmlEntityService.findByNameContaining("amp", pageable)
             val upperCasePage = htmlEntityService.findByNameContaining("AMP", pageable)


### PR DESCRIPTION
## Summary
- Migrate HtmlEntityRepository from ReactiveCrudRepository to CoroutineCrudRepository
- Update HtmlEntityService to use coroutine-based repository methods
- Refactor findByNameContaining method to use functional programming style
- Update all related test files to work with coroutine APIs

## Test plan
- [x] Verify all existing tests pass
- [x] Check that repository methods work with coroutine APIs
- [x] Confirm service layer properly handles async operations