### PR TITLE
ci: migrate GitHub workflows from PAT to GitHub App authentication

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ vars.DEV_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.DEV_AUTOMATION_PRIVATE_KEY }}

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -14,9 +14,16 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Generate GitHub App Token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.DEV_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.DEV_AUTOMATION_PRIVATE_KEY }}
+      
       - name: Comment to trigger Dependabot merge
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           gh pr comment $PR_NUMBER --body "@dependabot merge"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,17 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App Token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.DEV_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.DEV_AUTOMATION_PRIVATE_KEY }}
+      
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ steps.generate_token.outputs.token }}
           fetch-depth: 0  # Ensure full history is available for commit
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -25,13 +32,15 @@ jobs:
         run: ./gradlew spotlessApply --no-daemon
       - name: Commit changes if any
         run: |
-          git config --global user.name "github-actions"
-          git config --global user.email "github-actions@github.com"
+          git config --global user.name '${{ steps.generate_token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com'
           git add .
           if ! git diff --cached --exit-code; then
-            git commit -m "Apply code formatting with Spotless"
+            git commit -m "style: apply code formatting with Spotless"
             git push
           fi
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
   build:
     needs: format
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ vars.DEV_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.DEV_AUTOMATION_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Replace PAT usage with GitHub App authentication in auto-merge-dependabot.yml
- Replace PAT usage with GitHub App authentication in ci.yml
- Update commit author to use GitHub App bot identity
- Update commit message to follow Conventional Commits format

## Changes
- Added GitHub App token generation steps to both workflows
- Updated GITHUB_TOKEN references to use generated app tokens
- Modified git config to use app-slug based bot identity
- Changed commit message format to use 'style:' prefix