### PR TITLE
ci: migrate GitHub workflows from PAT to GitHub App authentication

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types:
       - opened
+      - synchronize
+      - reopened
 
 jobs:
   auto-merge-dependabot-prs:


### PR DESCRIPTION
## Summary
- Replace PAT usage with GitHub App authentication in auto-merge-dependabot.yml  
- Replace PAT usage with GitHub App authentication in ci.yml
- Update commit author to use GitHub App bot identity
- Update commit message to follow Conventional Commits format
- Add synchronize and reopened triggers to dependabot workflow

## Changes
- Updated to actions/create-github-app-token@v2
- Added GitHub App token generation steps to both workflows
- Updated GITHUB_TOKEN references to use generated app tokens
- Modified git config to use app-slug based bot identity
- Changed commit message format to use 'style:' prefix