### PR TITLE
ci: add checkout step to dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -23,6 +23,12 @@ jobs:
           app-id: ${{ vars.DEV_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.DEV_AUTOMATION_PRIVATE_KEY }}
       
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          fetch-depth: 0  # Ensure full history is available for commit
+      
       - name: Comment to trigger Dependabot merge
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
## Summary
- Add checkout step to dependabot auto-merge workflow to fix gh command execution

## Changes
- Added checkout step with GitHub App token authentication
- This ensures the gh command has access to repository context
- Fixes potential failures in gh pr comment command