### PR TITLE
fix: explicitly enable Renovate git-submodules manager

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,6 +9,9 @@
     "dockerfile",
     "git-submodules"
   ],
+  "git-submodules": {
+    "enabled": true
+  },
   "separateMajorMinor": false,
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

This PR enables submodule update automation in Renovate by explicitly opting into the `git-submodules` manager.

## Changes

- Update `renovate.json5` to add:
  - `"git-submodules": { "enabled": true }`

## Why this change

Renovate treats `git-submodules` as an opt-in manager. Listing it in `enabledManagers` alone is not sufficient in all configurations. This explicit manager block ensures Renovate creates submodule update PRs.

## Validation

- `npx --yes -p renovate renovate-config-validator --strict renovate.json5`
