### PR TITLE
chore(deps): enable Renovate gradle-wrapper manager

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,6 +5,7 @@
   "schedule": ["* 3 * * *"],
   "enabledManagers": [
     "gradle",
+    "gradle-wrapper",
     "github-actions",
     "dockerfile",
     "git-submodules"
@@ -18,6 +19,11 @@
       "matchManagers": ["gradle"],
       "groupName": "gradle dependencies",
       "groupSlug": "gradle-dependencies"
+    },
+    {
+      "matchManagers": ["gradle-wrapper"],
+      "groupName": "gradle wrapper",
+      "groupSlug": "gradle-wrapper"
     },
     {
       "matchManagers": ["github-actions"],
@@ -37,6 +43,7 @@
     {
       "matchManagers": [
         "gradle",
+        "gradle-wrapper",
         "github-actions",
         "dockerfile",
         "git-submodules"


### PR DESCRIPTION
## Summary
- Enable the `gradle-wrapper` manager in Renovate so Gradle Wrapper version updates are picked up automatically again.
- Add a dedicated `gradle wrapper` package group and include `gradle-wrapper` in the auto-merge rule, mirroring the existing per-manager grouping conventions.

## Changes
- `renovate.json5`
  - Add `gradle-wrapper` to `enabledManagers` (previously omitted, which implicitly disabled the manager).
  - Add a `packageRules` entry that groups `gradle-wrapper` updates under the `gradle wrapper` group with slug `gradle-wrapper`.
  - Add `gradle-wrapper` to the `matchManagers` list of the existing auto-merge rule.

## Test Plan
- Run `./gradlew spotlessCheck` — passes.
- Run `./gradlew build` — passes (unit tests + assemble + integrationTest).
- After merge, confirm Renovate opens a `gradle wrapper` PR for `gradle/wrapper/gradle-wrapper.properties` on the next scheduled run (`* 3 * * *` Asia/Tokyo).

## Checklist
- [ ] Code formatted (`./gradlew spotlessApply`) — not executed; the change is JSON5 only, which Spotless does not format. `spotlessCheck` confirms the existing Kotlin sources remain formatted.
- [x] Lint passes (`./gradlew spotlessCheck`)
- [x] Unit tests pass (`./gradlew test`) — covered by `./gradlew build`.
- [x] Integration tests pass (`./gradlew integrationTest`) — covered by `./gradlew build`.
- [x] Build succeeds (`./gradlew build`)
- [x] Documentation consistency verified

## Documentation Updates
- [x] Code changes are reflected in documentation
- [x] Documentation examples have been verified
- [x] No stale references to renamed/removed code

No documentation changes are required: no Markdown file under the repository references Renovate manager configuration.

## Related Issues
N/A