### PR TITLE
chore: align Renovate config with shared best practices

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,65 +1,74 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "timezone": "Asia/Tokyo",
-  "schedule": ["* 3 * * *"],
-  "enabledManagers": [
-    "gradle",
-    "gradle-wrapper",
-    "github-actions",
-    "dockerfile",
-    "git-submodules"
+  // Shared Renovate policy across seijikohara repositories.
+  // Schema: https://docs.renovatebot.com/renovate-schema.json
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    // Maintainer-recommended superset of config:recommended. Pins GitHub Action
+    // and Docker digests, enables config migration, dev-dependency pinning,
+    // weekly lock file maintenance, and the npm minimum-release-age cooldown.
+    "config:best-practices",
+    // Conventional Commits with a unified `chore(deps): ...` subject.
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)",
+    ":semanticCommitScope(deps)",
   ],
-  "git-submodules": {
-    "enabled": true
+  timezone: "Asia/Tokyo",
+  schedule: ["before 9am on monday"],
+  labels: ["dependencies"],
+  enabledManagers: ["gradle", "gradle-wrapper", "github-actions", "dockerfile", "docker-compose", "git-submodules"],
+  // The frontend/ directory is a git submodule; let Renovate track its pointer.
+  "git-submodules": { enabled: true },
+  // Keep update branches rebased on main and merge via rebase once CI passes.
+  rebaseWhen: "behind-base-branch",
+  platformAutomerge: true,
+  automergeStrategy: "rebase",
+  // Hold every release for 3 days so a hijacked publish cannot ride automerge on day zero.
+  minimumReleaseAge: "3 days",
+  packageRules: [
+    {
+      description: "Auto-merge non-major updates once CI passes",
+      matchUpdateTypes: ["minor", "patch", "pin", "digest"],
+      automerge: true,
+    },
+    {
+      description: "Hold major updates for manual review via the dependency dashboard",
+      matchUpdateTypes: ["major"],
+      automerge: false,
+      dependencyDashboardApproval: true,
+      addLabels: ["major"],
+    },
+    {
+      description: "Group and label GitHub Actions updates",
+      matchManagers: ["github-actions"],
+      groupName: "github-actions",
+      addLabels: ["github-actions"],
+    },
+    {
+      description: "Group the Gradle dependencies and wrapper",
+      matchManagers: ["gradle", "gradle-wrapper"],
+      groupName: "gradle",
+    },
+    {
+      description: "Group the Spring ecosystem",
+      groupName: "spring",
+      matchPackageNames: ["/^org\\.springframework/"],
+    },
+    {
+      description: "Group the Docker image references",
+      matchManagers: ["dockerfile", "docker-compose"],
+      groupName: "docker",
+    },
+    {
+      description: "Group the git submodule pointers",
+      matchManagers: ["git-submodules"],
+      groupName: "git submodules",
+    },
+  ],
+  vulnerabilityAlerts: {
+    description: "Raise security fixes immediately and require manual review",
+    schedule: ["at any time"],
+    minimumReleaseAge: null,
+    addLabels: ["security"],
+    automerge: false,
   },
-  "separateMajorMinor": false,
-  "packageRules": [
-    {
-      "matchManagers": ["gradle"],
-      "groupName": "gradle dependencies",
-      "groupSlug": "gradle-dependencies"
-    },
-    {
-      "matchManagers": ["gradle-wrapper"],
-      "groupName": "gradle wrapper",
-      "groupSlug": "gradle-wrapper"
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "groupName": "github actions dependencies",
-      "groupSlug": "github-actions-dependencies"
-    },
-    {
-      "matchManagers": ["dockerfile"],
-      "groupName": "docker dependencies",
-      "groupSlug": "docker-dependencies"
-    },
-    {
-      "matchManagers": ["git-submodules"],
-      "groupName": "git submodule dependencies",
-      "groupSlug": "git-submodule-dependencies"
-    },
-    {
-      "matchManagers": [
-        "gradle",
-        "gradle-wrapper",
-        "github-actions",
-        "dockerfile",
-        "git-submodules"
-      ],
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch",
-        "pin",
-        "digest",
-        "replacement",
-        "rollback"
-      ],
-      "automerge": true,
-      "automergeType": "pr",
-      "platformAutomerge": true
-    }
-  ]
 }


### PR DESCRIPTION
## Summary

Align the existing Renovate configuration with the shared best-practices policy used across the other repositories.

## Policy (shared across seijikohara repositories)

- Extends `config:best-practices`: pins GitHub Action and Docker digests, enables config migration, dev-dependency pinning, weekly lock file maintenance, and the npm release-age cooldown.
- Conventional Commits with a unified `chore(deps): ...` subject (`:semanticCommits` + `chore` / `deps`).
- Auto-merges `minor` / `patch` / `pin` / `digest` updates once CI passes; `major` updates are held for manual review via the Dependency Dashboard (`dependencyDashboardApproval`).
- Keeps branches rebased on `main` (`rebaseWhen: behind-base-branch`) and merges via rebase (`automergeStrategy: rebase`, platform automerge).
- 3-day `minimumReleaseAge` cooldown blunts day-zero supply-chain attacks; security fixes bypass the cooldown and are raised immediately (`vulnerabilityAlerts`).
- Unified labels (`dependencies`, plus `github-actions` / `major` / `security`) and grouping.
- Weekly schedule, `Asia/Tokyo` timezone.

## Validation

- `renovate-config-validator` (v43.235.2) passes.
